### PR TITLE
ReScript v11 syntax changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **Improvements:**
 
 - Improve syntax highlighting for escaped backticks in interpolated strings ([#55](https://github.com/rescript-lang/vim-rescript/pull/55))
-- Highlight improvements ([#69](https://github.com/rescript-lang/vim-rescript/pull/69))
+- Highlight improvements ([#69](https://github.com/rescript-lang/vim-rescript/pull/69)) and https://github.com/rescript-lang/vim-rescript/pull/78
 - Support `commentstring`. https://github.com/rescript-lang/vim-rescript/pull/76
 
 ## 2.1.0

--- a/syntax/rescript.vim
+++ b/syntax/rescript.vim
@@ -18,7 +18,7 @@ syntax keyword resException try catch exception assert
 syntax keyword resKeyword async await
 
 " Types
-syntax keyword resType bool int float char string unit promise
+syntax keyword resType bool int float char string unit promise dict result
 syntax keyword resType array option ref exn format
 syntax match resType "list{\@!"
 
@@ -47,6 +47,8 @@ syntax match resOperator "\v\@"
 
 syntax match resOperator "\v\!"
 syntax match resOperator "\v\&"
+syntax match resOperator "\v\:\>"
+syntax match resOperator "\v\.\.\."
 
 " Delimiter
 syntax match resDelimiter "\v\|"
@@ -101,8 +103,7 @@ syntax region resCustomOperator start="\v\\\"" end="\v\""
 " Interpolation
 syntax match resInterpolationVariable "\v\$[a-z_][A-Za-z0-0_'$]*" contained
 syntax region resInterpolationBlock matchgroup=resInterpolationDelimiters start="\v\$\{" end="\v\}" contained contains=TOP
-syntax region resString start="\v`" end="\v`" contains=resInterpolationBlock,resInterpolatedStringEscapeSeq
-syntax region resString start="\v[a-z]`" end="\v`" contains=resInterpolationBlock,resInterpolationVariable,resInterpolatedStringEscapeSeq
+syn region  resString start=+`+  skip=+\\\\\|\\`+  end=+`+	contains=resInterpolationBlock,resInterpolationVariable,resInterpolatedStringEscapeSeq
 
 " Polymorphic variants
 syntax match resPolyVariant "\v#[A-za-z][A-Za-z0-9_'$]*"

--- a/test/syntax/expected/highlight.res.txt
+++ b/test/syntax/expected/highlight.res.txt
@@ -301,4 +301,36 @@
         hl_group = "resType",
         hl_group_link = "Type"
       } }
+  }, {
+    col = 9,
+    row = 135,
+    syntax = {}
+  }, {
+    col = 10,
+    row = 138,
+    syntax = { {
+        hl_group = "resType",
+        hl_group_link = "Type"
+      } }
+  }, {
+    col = 10,
+    row = 141,
+    syntax = { {
+        hl_group = "resType",
+        hl_group_link = "Type"
+      } }
+  }, {
+    col = 21,
+    row = 144,
+    syntax = { {
+        hl_group = "resNone",
+        hl_group_link = "resNone"
+      } }
+  }, {
+    col = 7,
+    row = 147,
+    syntax = { {
+        hl_group = "resNone",
+        hl_group_link = "resNone"
+      } }
   } }

--- a/test/syntax/expected/highlight.res.txt
+++ b/test/syntax/expected/highlight.res.txt
@@ -150,6 +150,9 @@
     syntax = { {
         hl_group = "resNone",
         hl_group_link = "resNone"
+      }, {
+        hl_group = "resOperator",
+        hl_group_link = "Operator"
       } }
   }, {
     col = 9,
@@ -332,5 +335,8 @@
     syntax = { {
         hl_group = "resNone",
         hl_group_link = "resNone"
+      }, {
+        hl_group = "resOperator",
+        hl_group_link = "Operator"
       } }
   } }

--- a/test/syntax/highlight.res
+++ b/test/syntax/highlight.res
@@ -132,3 +132,18 @@ let ref = ref(false)
    //^
 let option = None
     //^
+
+let _ = sql`select * from table`
+        //^
+
+type a = dict<string>
+         //^
+
+type b = result<int, string>
+         //^
+
+let _ = (x: r1) => (x :> r2)
+                    //^
+
+foo(1, ...)
+      //^


### PR DESCRIPTION
- highlight `dict`, `result`, `:>` and `...`
- Don't highlight template string prefix